### PR TITLE
Fix syntax in default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
   <body>
     <header>
       <img src="/site/logo.jpeg" alt="Lemonade Stand Logo" class="logo" />
-      <h1><a href=/"site/">Lemonade Stand Podcast</a></h1>
+      <h1><a href="/site/">Lemonade Stand Podcast</a></h1>
     </header>
     <main>
       {{ content }}


### PR DESCRIPTION
Syntax error is leading to 404 message when clicking the Lemonade Stand Podcast link in the header